### PR TITLE
[Improvement][Levis]: Support Disabling Liveness And Readiness Probe

### DIFF
--- a/examples/levis-disable-health-check.yaml
+++ b/examples/levis-disable-health-check.yaml
@@ -1,0 +1,8 @@
+levis:
+  name: "nginx"
+  deployment:
+    enableHealthCheck: false
+    containers:
+      image: "nginx"
+  service:
+    enable: true

--- a/src/models/levisConfig.ts
+++ b/src/models/levisConfig.ts
@@ -13,16 +13,17 @@ interface Levis {
 
 /* Deployment Section */
 interface Deployment {
-    name?: string;
-    labels?: { [key: string]: string };
-    annotations?: { [key: string]: string };
-    revisionHistoryLimit?: number;
-    replicas?: number;
-    strategy?: Strategy;
-    matchLabels?: { [key: string]: string };
-    serviceAccount?: string;
-    containers: Containers;
-    node: Node;
+  name?: string;
+  labels?: { [key: string]: string };
+  annotations?: { [key: string]: string };
+  revisionHistoryLimit?: number;
+  replicas?: number;
+  strategy?: Strategy;
+  matchLabels?: { [key: string]: string };
+  serviceAccount?: string;
+  containers: Containers;
+  node: Node;
+  enableHealthCheck?: boolean;
 }
 
 interface Node {


### PR DESCRIPTION
- from issue: https://github.com/kubeopsskills/levis/issues/9
- can add enableHealthCheck for config enable or disable health check if not config health check is enable by default
- config example
```yaml
levis:
  name: "nginx"
  deployment:
    enableHealthCheck: false
    containers:
      image: "nginx"
  service:
    enable: true
```