### PR TITLE
[Improvement][Log4js]: Add log level when run cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,19 @@
 This is an project built with ❤️ by [KubeOps Skills](https://www.kubeops.guru). We encourage you to [try it out](#getting-started), [leave feedback](#help--feedback), and [jump in to help](#contributing)!
 
 ### Contents
-- [Versioning](#versioning)
-- [Demo](#demo)
-- [Getting Started](#getting-started)
-- [Help & Feedback](#help--feedback)
-- [Examples](#examples)
-- [Roadmap](#roadmap)
-- [Contributing](#contributing)
-- [License](#license)
+- [Levis](#levis)
+  - [Kubernetes Manifest Generator](#kubernetes-manifest-generator)
+    - [Contents](#contents)
+  - [Versioning](#versioning)
+  - [Demo](#demo)
+  - [Getting Started](#getting-started)
+    - [Installation](#installation)
+    - [Usage](#usage)
+  - [Help & Feedback](#help--feedback)
+  - [Examples](#examples)
+  - [Roadmap](#roadmap)
+  - [Contributing](#contributing)
+  - [License](#license)
 
 ## Versioning
 | Levis Release |cdk8s Version | construct Version | log4js Version | minimist Version | yaml Version |
@@ -27,6 +32,15 @@ This is an project built with ❤️ by [KubeOps Skills](https://www.kubeops.gur
 ### Installation
 Levis is available on Linux, macOS and Windows platforms.
 - Binaries for Linux, Windows and Mac are available as tarballs in the [release](https://github.com/kubeopsskills/levis/releases) page.
+
+### Usage
+after install levis you can use
+- `levis create -f <levis-config.yaml> -o <output.yaml>`
+- **-f** levis config yaml see [Examples Directory](./examples)
+- **-o** name of kubernetes config generated from levis
+- **-v** log level
+  -  1 for info (default)
+  -  2 for debug
 
 ## Help & Feedback
 Interacting with the community and the development team is a great way to

--- a/main.ts
+++ b/main.ts
@@ -2,19 +2,29 @@ import { App } from "cdk8s";
 import * as log4js from "log4js";
 import * as Minimist from "minimist";
 import { CommandManager } from './src/managers/commandManager';
+import { LogConfig } from "./src/utils";
 
-const log = log4js.getLogger();
+// Setup log config
 log4js.configure({
   appenders: {
-    out: { type: 'stdout', layout: {
-      type: 'pattern',
-      pattern: '%[%d [%p] %f{1} line: %l - %m%n%]',
-    }}
+    out: {
+      type: "stdout",
+      layout: {
+        type: "pattern",
+        pattern: "%[%d [%p] %f{1} line: %l - %m%n%]",
+      },
+    },
   },
-  categories: { 
-    default: { appenders: ['out'], level: 'info', enableCallStack: true }
-  }
-})
+  categories: {
+    default: {
+      appenders: ["out"],
+      level: LogConfig.logLevel(process.argv),
+      enableCallStack: true,
+    },
+  },
+});
+
+const log = log4js.getLogger();
 
 /// levis command line interface
 /// levis <position-0> <position-1> <position-2>

--- a/src/utils/configParser.ts
+++ b/src/utils/configParser.ts
@@ -46,13 +46,13 @@ export class ConfigParser {
 
     private static createToleration(config: LevisConfig): Toleration[] | undefined {
         const toleration: Toleration[] = []
-        const allower = config.levis.deployment.node.allower || undefined;
+        const allower = config.levis.deployment.node?.allower || undefined;
         const keyList: Array<string> = ['effect', 'operator'];
         if(!allower) {
             return undefined;
         } 
         for(let i=0; i<allower?.length; i++) {
-            for(let[key, value] of Object.entries(allower[i]) ){
+            for(const[key, value] of Object.entries(allower[i]) ){
                 if(keyList.includes(key)){continue;}
                 toleration.push({
                     effect: allower[i].effect,
@@ -179,7 +179,7 @@ export class ConfigParser {
         const envVar: EnvVar[] = []
         const envField = config.levis.deployment.containers.envField || [];
         for (let i=0; i<envField?.length; i++){
-            for(let [key, value] of Object.entries(envField[i])) {
+            for(const [key, value] of Object.entries(envField[i])) {
                 envVar.push(
                     {  
                         name: key,
@@ -273,8 +273,8 @@ export class ConfigParser {
         const rollingUpdateType: string = config.levis.deployment.strategy?.type || Constants.Deployment.STRATEGY_ROLLING_UPDATE;
         const maxSurge: string = config.levis.deployment.strategy?.rollingUpdate?.maxSurge || Constants.Deployment.ROLLING_UPDATE_MAX_SURGE;
         const maxUnavailable: string = config.levis.deployment.strategy?.rollingUpdate?.maxUnavailable || Constants.Deployment.ROLLING_UPDATE_MAX_UNAVAILABLE;
-        const affinity = config.levis.deployment.node.selector ? this.createAffinity(config): {};
-        const toleration: Toleration[]| undefined = config.levis.deployment.node.allower ? this.createToleration(config): undefined;
+        const affinity = config.levis.deployment.node?.selector ? this.createAffinity(config): {};
+        const toleration: Toleration[]| undefined = config.levis.deployment.node?.allower ? this.createToleration(config): undefined;
         log.debug("affinity: ", JSON.stringify(affinity));
         const strategy = this.createDeploymentStrategy(
             this.isRollingUpdateEnable(rollingUpdateType),

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,8 +1,11 @@
 import { ConfigParser } from "./configParser";
 import { FileUtils } from "./fileUtils";
 import { TypeMapper } from "./typeMapper";
+import { LogConfig } from "./logConfig";
+
 export {
     ConfigParser,
     FileUtils,
-    TypeMapper
+    TypeMapper,
+    LogConfig,
 };

--- a/src/utils/logConfig.ts
+++ b/src/utils/logConfig.ts
@@ -1,0 +1,22 @@
+import * as Minimist from "minimist";
+
+
+export class LogConfig {
+
+  public static logLevel(args: string[]): string {
+    const logLevelArgs = Minimist(args.slice(7));
+    const defaultLogLevel = "info";
+
+    if (logLevelArgs) {
+      switch (logLevelArgs["v"]) {
+        case 1:
+          return defaultLogLevel;
+        case 2:
+          return "debug";
+      }
+    }
+    
+    return defaultLogLevel;
+  }
+  
+}


### PR DESCRIPTION
- `levis create -f <levis-config.yaml> -o <output.yaml> -v <log level>`
- **-f** levis config yaml see [Examples Directory](./examples)
- **-o** name of kubernetes config generated from levis
- **-v** log level
  -  1 for info (default)
  -  2 for debug
